### PR TITLE
Add --prepare-release to include unreleased merges when prepare release

### DIFF
--- a/exe/git-chlog
+++ b/exe/git-chlog
@@ -97,16 +97,16 @@ class Release
   end
 end
 
-module GitRepo
-  def self.origin_remote_url
+class GitRepo
+  def origin_remote_url
     `git remote get-url origin`.strip
   end
 
-  def self.first_commit_sha
+  def first_commit_sha
     `git rev-list --max-parents=0 HEAD`.strip[0...9]
   end
 
-  def self.prev_tag(current_tag)
+  def prev_tag(current_tag)
     `git log --format="%D" #{current_tag}~1`
       .split("\n")
       .select { |line| line.start_with?("tag:") }
@@ -114,11 +114,11 @@ module GitRepo
       &.match(/tag: ([^,]+)/)&.captures&.first
   end
 
-  def self.load_releases
+  def load_releases
     LoadReleases.new(git_repo: self).call
   end
 
-  def self.load_merged_requests(release, code_hosting)
+  def load_merged_requests(release, code_hosting)
     LoadMergedRequests.new(
       release: release, code_hosting: code_hosting
     ).call
@@ -279,8 +279,9 @@ class PrintChangeLog
     end
 end
 
+git_repo = GitRepo.new
 PrintChangeLog.new(
-  code_hosting: CodeHosting.build(GitRepo.origin_remote_url),
-  git_repo: GitRepo,
+  code_hosting: CodeHosting.build(git_repo.origin_remote_url),
+  git_repo: git_repo,
   issue_tracker: IssueTracker::PivotalTracker
 ).call

--- a/exe/git-chlog
+++ b/exe/git-chlog
@@ -74,12 +74,18 @@ module CodeHosting
 end
 
 class Release
-  attr_reader :tag, :date
+  attr_reader :tag, :git_ref, :label, :date
   attr_accessor :prev_tag
 
-  def initialize(tag:, date:)
+  def self.build_head(tag: "HEAD", label: "Unreleased")
+    Release.new(tag: tag, date: Time.now, git_ref: "HEAD", label: label)
+  end
+
+  def initialize(tag:, date:, git_ref: nil, label: nil)
     @tag = tag
-    @date = Time.parse(date)
+    @git_ref = git_ref || tag
+    @label = label || tag
+    @date = Time.parse(date.to_s)
   end
 
   def version_number
@@ -169,7 +175,7 @@ module GitRepo
       end
 
       def tag_range
-        [release.tag, release.prev_tag].compact.join("...")
+        [release.git_ref, release.prev_tag].compact.join("...")
       end
 
       def is_merge_request?(raw_commit)
@@ -229,8 +235,8 @@ class PrintChangeLog
   private
 
     def print_release_heading(out, release)
-      out.puts("## [#{release.tag}](#{code_hosting.tag_url(release.tag)})")
-      out.puts("Released on #{format_date(release.date)}")
+      out.puts("## [#{release.label}](#{code_hosting.tag_url(release.tag)})")
+      out.puts("#{format_date(release.date)}")
     end
 
     def print_full_changelog_link(out, release)

--- a/exe/git-chlog
+++ b/exe/git-chlog
@@ -77,7 +77,7 @@ class Release
   attr_reader :tag, :git_ref, :label, :date
   attr_accessor :prev_tag
 
-  def self.build_head(tag: "HEAD", label: "Unreleased")
+  def self.build_head(tag:, label:)
     Release.new(tag: tag, date: Time.now, git_ref: "HEAD", label: label)
   end
 
@@ -98,6 +98,12 @@ class Release
 end
 
 class GitRepo
+  attr_reader :options
+
+  def initialize(options = {})
+    @options = options.dup
+  end
+
   def origin_remote_url
     `git remote get-url origin`.strip
   end
@@ -115,7 +121,10 @@ class GitRepo
   end
 
   def load_releases
-    LoadReleases.new(git_repo: self).call
+    LoadReleases.new(
+      git_repo: self,
+      head_release_tag: options[:prepare_release]
+    ).call
   end
 
   def load_merged_requests(release, code_hosting)
@@ -125,10 +134,11 @@ class GitRepo
   end
 
   class LoadReleases
-    attr_reader :git_repo
+    attr_reader :git_repo, :head_release_tag
 
-    def initialize(git_repo:)
+    def initialize(git_repo:, head_release_tag:)
       @git_repo = git_repo
+      @head_release_tag = head_release_tag
     end
 
     def call
@@ -140,10 +150,19 @@ class GitRepo
         }
         .sort
         .reverse
-        .unshift(Release.build_head)
+        .unshift(head_release)
+        .compact
     end
 
     private
+
+      def head_release
+        if head_release_tag
+          Release.build_head(tag: head_release_tag, label: head_release_tag)
+        else
+          nil
+        end
+      end
 
       def raw_git_tag_data
         `git tag --format='%(refname:short)|%(creatordate:iso8601)'`
@@ -279,7 +298,27 @@ class PrintChangeLog
     end
 end
 
-git_repo = GitRepo.new
+options = {
+  prepare_release: false
+}
+
+require 'optparse'
+OptionParser.new do |opts|
+  opts.banner = "Usage: git chlog [options]"
+
+  opts.on(
+    "--prepare-release=[TAG]",
+    "Add unreleased changes when preparing new release") do |tag|
+    options[:prepare_release] = tag || "HEAD"
+  end
+
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end.parse!
+
+git_repo = GitRepo.new(options)
 PrintChangeLog.new(
   code_hosting: CodeHosting.build(git_repo.origin_remote_url),
   git_repo: git_repo,

--- a/exe/git-chlog
+++ b/exe/git-chlog
@@ -140,6 +140,7 @@ module GitRepo
         }
         .sort
         .reverse
+        .unshift(Release.build_head)
     end
 
     private


### PR DESCRIPTION
Changes:
- Add --prepare-release option to include unreleased HEAD changes
- Switch GitRepo from module to class
- Add Release#label, #git_ref to model HEAD release