### PR TITLE
Downgrade regexp syntax to be compatible with ruby <2.4

### DIFF
--- a/exe/git-chlog
+++ b/exe/git-chlog
@@ -26,7 +26,7 @@ module CodeHosting
     attr_reader :repo_name
 
     def self.matching_repo_url?(repo_url)
-      /github\.com/.match?(repo_url)
+      !(/github\.com/.match(repo_url).nil?)
     end
 
     def initialize(github_repo_url)


### PR DESCRIPTION
Fix: https://github.com/teohm/git-chlog/issues/6

Changes:
- Replace Regexp#match? which only available since Ruby 2.4